### PR TITLE
feat: enhance the benchmark script to handle --workload option in any argument position

### DIFF
--- a/benchmark-scripts/benchmark.sh
+++ b/benchmark-scripts/benchmark.sh
@@ -33,6 +33,7 @@ show_help() {
 }
 
 OPTIONS_TO_SKIP=0
+DOCKER_RUN_ARGS=""
 
 get_options() {
     while :; do
@@ -92,15 +93,15 @@ get_options() {
           echo "init_duration: $COMPLETE_INIT_DURATION"
           shift
           ;;
-        -?*)
-            break
-            ;;
+        --*)
+          DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS $1"
+          ;;
         ?*)
-            break
-            ;;
+          DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS $1"
+          ;;
         *)
-            break
-            ;;
+          break
+          ;;
         esac
 
         OPTIONS_TO_SKIP=$(( $OPTIONS_TO_SKIP + 1 ))
@@ -131,6 +132,8 @@ get_options "$@"
 
 # load docker-run params
 shift $OPTIONS_TO_SKIP
+set -- $@ $DOCKER_RUN_ARGS
+echo "arguments passing to get-optons.sh $@"
 source ../get-options.sh "$@"
 
 # set performance mode


### PR DESCRIPTION
  Now if --workload is placed in front of pipeline options, it will work.  Also works if placed in-between or after the pipeline options.

  Closes: #67

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->
--workload can work in any position when running benchmark.sh script

## Issue this PR will close

close: #**67**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
can test with either position of --workload
- sudo benchmark.sh --pipelines 1 --logdir mytest/data --duration 120 --init_duration 60 --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0 --workload dlstreamer --ocr_disabled --barcode_disabled --classification_disabled
- sudo benchmark.sh --pipelines 1  --workload dlstreamer --logdir mytest/data --duration 120 --init_duration 60 --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0 --ocr_disabled --barcode_disabled --classification_disabled

both cases should run as normal and works without any syntax error for benchmark.sh script

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
