### PR TITLE
fix: fixed docker-run.sh with wrong message when no --workload option

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,6 +6,7 @@
 #
 
 source benchmark-scripts/get-gpu-info.sh
+# Default WORKLOAD_SCRIPT to dlstreamer workload if not provided
 WORKLOAD_SCRIPT="docker-run-dlstreamer.sh"
 
 if [ -z "$PLATFORM" ] || [ -z "$INPUTSRC" ]

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,13 +6,12 @@
 #
 
 source benchmark-scripts/get-gpu-info.sh
+WORKLOAD_SCRIPT="docker-run-dlstreamer.sh"
 
 if [ -z "$PLATFORM" ] || [ -z "$INPUTSRC" ]
 then
 	source get-options.sh "$@"
 fi
 
-#todo figure out how to have the workload script see the env variables set by get-options.sh so that it doesn't have to be run twice. 
-# or modify this script to determine the workload script
 echo "running $WORKLOAD_SCRIPT"
 ./$WORKLOAD_SCRIPT "$@"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,7 +6,7 @@
 #
 
 source benchmark-scripts/get-gpu-info.sh
-# Default WORKLOAD_SCRIPT to dlstreamer workload if not provided
+# WORKLOAD_SCRIPT is env varilable will be overwritten by --workload input option
 WORKLOAD_SCRIPT="docker-run-dlstreamer.sh"
 
 if [ -z "$PLATFORM" ] || [ -z "$INPUTSRC" ]


### PR DESCRIPTION
Closes: #75

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
set WORKLOAD_SCRIPT default to docker-run-dlstream.sh so it will correct the message.

## Issue this PR will close

close: #75 

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
1. go to xeon or arc supported machine using meshcentral.com
2. on automated-self-checkout directory, call command `./docker-run.sh --platform core --inputsrc rstp://127.0.0.1:8554/camera_0`
3. when not providing --workload, it should default to dlstreamer pipeline run.

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
