### PR TITLE
fix: Resolve the issue of OVMS stream density mode for grpc_python pipeline profile

### DIFF
--- a/configs/dlstreamer/framework-pipelines/stream_density.sh
+++ b/configs/dlstreamer/framework-pipelines/stream_density.sh
@@ -195,7 +195,7 @@ do
         do
 		#fps=`tail -1 /tmp/results/pipeline$cid_count.log`
 		# Last 10/20 seconds worth of currentfps
-	        STREAM_FPS_LIST=`tail -20 /tmp/results/pipeline$i.log`
+	    STREAM_FPS_LIST=`tail -20 /tmp/results/pipeline$i.log`
 		if [ -z "$STREAM_FPS_LIST" ]
 		then
 			echo "Warning: No FPS returned from pipeline$i.log"
@@ -203,15 +203,15 @@ do
 			echo "DEBUG: $STREAM_FPS_LIST"
 			#continue
 		fi
-        	stream_fps_sum=0
-        	stream_fps_count=0
+        stream_fps_sum=0
+        stream_fps_count=0
 
 		for stream_fps in $STREAM_FPS_LIST
-        	do
+        do
                 	stream_fps_sum=`echo $stream_fps_sum $stream_fps | awk '{print $1 + $2}'`
                 	stream_fps_count=`echo $stream_fps_count 1 | awk '{print $1 + $2}'`
-        	done
-        	stream_fps_avg=`echo $stream_fps_sum $stream_fps_count | awk '{print $1 / $2}'`
+        done
+        stream_fps_avg=`echo $stream_fps_sum $stream_fps_count | awk '{print $1 / $2}'`
 
 
 		total_fps=`echo $total_fps $stream_fps_avg | awk '{print $1 + $2}'`
@@ -277,3 +277,5 @@ do
 	num_pipelines=$(( $num_pipelines + $increments ))
 
 done #done while
+
+echo "stream_density done!" >> $log

--- a/configs/opencv-ovms/cmd_client/main.go
+++ b/configs/opencv-ovms/cmd_client/main.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	scriptDir              = "/scripts"
-	pipelineProfileEnv     = "PIPELINE_PROFILE"
-	resourceDir            = "res"
-	pipelineConfigFileName = "configuration.yaml"
+	scriptDir                = "/scripts"
+	pipelineProfileEnv       = "PIPELINE_PROFILE"
+	resourceDir              = "res"
+	pipelineConfigFileName   = "configuration.yaml"
+	commandLineArgsDelimiter = " "
 )
 
 type OvmsClientInfo struct {
@@ -70,7 +71,9 @@ func launchPipelineScript(ovmsClientConf OvmsClientConfig) error {
 	if streamDensityMode == "1" {
 		log.Println("in stream density mode!")
 		scriptFilePath = "/home/pipeline-server/stream_density_framework-pipelines.sh"
-		inputArgs = []string{filepath.Join(scriptDir, ovmsClientConf.OvmsClient.PipelineScript)}
+		inputArgs = []string{filepath.Join(scriptDir, ovmsClientConf.OvmsClient.PipelineScript+
+			commandLineArgsDelimiter+
+			ovmsClientConf.OvmsClient.PipelineInputArgs)}
 	}
 
 	executable, err := exec.LookPath(scriptFilePath)
@@ -111,7 +114,7 @@ func parseInputArguments(ovmsClientConf OvmsClientConfig) []string {
 	trimmedArgs := strings.TrimSpace(ovmsClientConf.OvmsClient.PipelineInputArgs)
 	if len(trimmedArgs) > 0 {
 		// arguments in command is space delimited
-		return strings.Split(trimmedArgs, " ")
+		return strings.Split(trimmedArgs, commandLineArgsDelimiter)
 	}
 	return inputArgs
 }


### PR DESCRIPTION
  Fixes: #187

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->
Add the missing PipelineInputArgs in ovms-client code when running in stream-density mode

## Issue this PR will close

close: #**187**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
 - git clone this PR
- re-build the ovms-client: `make build-ovms-client`
- change directory to **benchmark_scripts** folder
- if you have not built the benchmark docker images, do the command `make` to build all benchmark related docker images.
- run stream density with grpc_python pipeline profile: `PIPELINE_PROFILE="grpc_python" sudo -E ./benchmark.sh --stream_density 14.9 --logdir mytest/data --duration 120 --init_duration 20 --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0 --workload opencv-ovms`
- once it is done, check the stream_density log in ../results/ folder, you should see the max number of pipelines to support the target FPS in the log: `cat ../results/stream_density.log` 
- 
## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
