### PR TITLE
feat: output FPS for go pipeline

### DIFF
--- a/configs/opencv-ovms/grpc_go/Dockerfile
+++ b/configs/opencv-ovms/grpc_go/Dockerfile
@@ -25,6 +25,6 @@ RUN protoc --go_out="./" --go-grpc_out="./" ./grpc_predict_v2.proto
 COPY . .
 
 RUN go mod tidy
-RUN go build -o grpc-go
+RUN go build -o grpc-go && chmod +x entrypoint.sh
 
-ENTRYPOINT ["./grpc-go", "-i", "rtsp://127.0.0.1:8554/camera_0", "-u", "127.0.0.1:9000"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/configs/opencv-ovms/grpc_go/entrypoint.sh
+++ b/configs/opencv-ovms/grpc_go/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+GRPC_PORT="${GRPC_PORT:=9000}"
+
+echo "running grpc_go with GRPC_PORT=$GRPC_PORT"
+
+
+./grpc-go -i $inputsrc -u 127.0.0.1:$GRPC_PORT -o /tmp/results 2>&1  | tee >/tmp/results/r$cid_count.jsonl >(stdbuf -oL sed -n -e 's/^.*fps: //p' | stdbuf -oL cut -d , -f 1 > /tmp/results/pipeline$cid_count.log)

--- a/configs/opencv-ovms/grpc_go/entrypoint.sh
+++ b/configs/opencv-ovms/grpc_go/entrypoint.sh
@@ -5,4 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-./grpc-go -i $inputsrc -u 127.0.0.1:$GRPC_PORT -o /tmp/results 2>&1  | tee >/tmp/results/r$cid_count.jsonl >(stdbuf -oL sed -n -e 's/^.*fps: //p' | stdbuf -oL cut -d , -f 1 > /tmp/results/pipeline$cid_count.log)
+if [ ! -z "$DEBUG" ]
+then
+    ./grpc-go -i $inputsrc -u 127.0.0.1:$GRPC_PORT
+else
+    ./grpc-go -i $inputsrc -u 127.0.0.1:$GRPC_PORT 2>&1  | tee >/tmp/results/r$cid_count.jsonl >(stdbuf -oL sed -n -e 's/^.*fps: //p' | stdbuf -oL cut -d , -f 1 > /tmp/results/pipeline$cid_count.log)
+fi

--- a/configs/opencv-ovms/grpc_go/entrypoint.sh
+++ b/configs/opencv-ovms/grpc_go/entrypoint.sh
@@ -5,9 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GRPC_PORT="${GRPC_PORT:=9000}"
-
-echo "running grpc_go with GRPC_PORT=$GRPC_PORT"
-
-
 ./grpc-go -i $inputsrc -u 127.0.0.1:$GRPC_PORT -o /tmp/results 2>&1  | tee >/tmp/results/r$cid_count.jsonl >(stdbuf -oL sed -n -e 's/^.*fps: //p' | stdbuf -oL cut -d , -f 1 > /tmp/results/pipeline$cid_count.log)

--- a/configs/opencv-ovms/grpc_go/main.go
+++ b/configs/opencv-ovms/grpc_go/main.go
@@ -11,7 +11,6 @@ import (
 	"image/color"
 	"log"
 	"net/http"
-	"os"
 	"time"
 	grpc_client "videoProcess/grpc-client"
 	"videoProcess/pkg/ovms"
@@ -71,14 +70,6 @@ func runModelServer(client *grpc_client.GRPCInferenceServiceClient, webcam *gocv
 	var aggregateLatencyAfterFinalProcess float64
 	var frameNum float64
 
-	// output latency metic to txt
-	latencyMetricFile := output + "/latency.txt"
-	file, err := os.Create(latencyMetricFile)
-	if err != nil {
-		fmt.Printf("failed to write to file:%v", err)
-	}
-	defer file.Close()
-
 	for webcam.IsOpened() {
 		if ok := webcam.Read(img); !ok {
 			// retry once after 1 millisecond
@@ -105,12 +96,6 @@ func runModelServer(client *grpc_client.GRPCInferenceServiceClient, webcam *gocv
 		afterInfer := float64(time.Now().UnixMilli())
 		aggregateLatencyAfterInfer += afterInfer - start
 
-		latencyStr := fmt.Sprintf("latency after infer: %v\n", aggregateLatencyAfterInfer/frameNum)
-		_, err = file.WriteString(latencyStr)
-		if err != nil {
-			fmt.Printf("failed to write to file:%v", err)
-		}
-
 		detectedObjects := yolov5.DetectedObjects{}
 
 		// temp code:
@@ -123,19 +108,13 @@ func runModelServer(client *grpc_client.GRPCInferenceServiceClient, webcam *gocv
 		if err != nil {
 			fmt.Printf("post process failed: %v\n", err)
 		}
-		fmt.Printf("length of detectedObjects after  processing: %v\n", len(detectedObjects.Objects))
-		detectedObjects = detectedObjects.FinalPostProcessAdvanced()
-		// debug
-		fmt.Printf("length of detectedObjects after final processing: %v\n", len(detectedObjects.Objects))
 
 		// Print after processing latency
 		afterFinalProcess := float64(time.Now().UnixMilli())
-		aggregateLatencyAfterFinalProcess += afterFinalProcess - start
-		latencyStr = fmt.Sprintf("average latency after final process: %v\n", aggregateLatencyAfterFinalProcess/frameNum)
-		_, err = file.WriteString(latencyStr)
-		if err != nil {
-			fmt.Printf("failed to write to file:%v", err)
-		}
+		processTime := afterFinalProcess - start
+		aggregateLatencyAfterFinalProcess += processTime
+		averageFPSStr := fmt.Sprintf("%v\n", aggregateLatencyAfterFinalProcess/frameNum)
+		fmt.Printf("Processing time: %v ms; fps: %s", processTime, averageFPSStr)
 
 		// add bounding boxes to resixed image
 		detectedObjects.AddBoxesToFrame(&fp32Image, color.RGBA{0, 255, 0, 0}, camWidth, camWidth)

--- a/configs/opencv-ovms/grpc_go/main.go
+++ b/configs/opencv-ovms/grpc_go/main.go
@@ -109,6 +109,8 @@ func runModelServer(client *grpc_client.GRPCInferenceServiceClient, webcam *gocv
 			fmt.Printf("post process failed: %v\n", err)
 		}
 
+		detectedObjects = detectedObjects.FinalPostProcessAdvanced()
+
 		// Print after processing latency
 		afterFinalProcess := float64(time.Now().UnixMilli())
 		processTime := afterFinalProcess - start

--- a/configs/opencv-ovms/grpc_go/main.go
+++ b/configs/opencv-ovms/grpc_go/main.go
@@ -55,7 +55,7 @@ func main() {
 	// create the mjpeg stream
 	stream := mjpeg.NewStream()
 
-	go runModelServer(&client, webcam, &img, FLAGS.ModelName, FLAGS.ModelVersion, stream, camWidth, camHeight, FLAGS.Output)
+	go runModelServer(&client, webcam, &img, FLAGS.ModelName, FLAGS.ModelVersion, stream, camWidth, camHeight)
 	fmt.Println("Capturing. Point your browser to " + FLAGS.Host)
 
 	// start http server
@@ -65,7 +65,7 @@ func main() {
 }
 
 func runModelServer(client *grpc_client.GRPCInferenceServiceClient, webcam *gocv.VideoCapture, img *gocv.Mat, modelname string,
-	modelVersion string, stream *mjpeg.Stream, camWidth float32, camHeight float32, output string) {
+	modelVersion string, stream *mjpeg.Stream, camWidth float32, camHeight float32) {
 	var aggregateLatencyAfterInfer float64
 	var aggregateLatencyAfterFinalProcess float64
 	var frameNum float64

--- a/configs/opencv-ovms/scripts/run_grpc_go.sh
+++ b/configs/opencv-ovms/scripts/run_grpc_go.sh
@@ -14,4 +14,4 @@ then
 fi
 
 echo $rmDocker
-docker run --network host --privileged $rmDocker -v $RUN_PATH/results:/tmp/results --name dev -p 8080:8080 grpc:dev bash -c './grpc-go -i $inputsrc -u 127.0.0.1:$GRPC_PORT -o /tmp/results'
+docker run --network host --privileged $rmDocker -e inputsrc="$inputsrc" -e cid_count="$cid_count" -e GRPC_PORT="$GRPC_PORT" -v $RUN_PATH/results:/tmp/results --name dev -p 8080:8080 grpc:dev

--- a/configs/opencv-ovms/scripts/run_grpc_go.sh
+++ b/configs/opencv-ovms/scripts/run_grpc_go.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# Copyright (C) 2023 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 GRPC_PORT="${GRPC_PORT:=9000}"
 

--- a/configs/opencv-ovms/scripts/run_grpc_go.sh
+++ b/configs/opencv-ovms/scripts/run_grpc_go.sh
@@ -19,4 +19,4 @@ then
 fi
 
 echo $rmDocker
-docker run --network host --privileged $rmDocker -e inputsrc="$inputsrc" -e cid_count="$cid_count" -e GRPC_PORT="$GRPC_PORT" -v $RUN_PATH/results:/tmp/results --name dev -p 8080:8080 grpc:dev
+docker run --network host --privileged $rmDocker -e inputsrc="$inputsrc" -e cid_count="$cid_count" -e GRPC_PORT="$GRPC_PORT" -e DEBUG="$DEBUG" -v $RUN_PATH/results:/tmp/results --name dev -p 8080:8080 grpc:dev


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
grpc-go pipeline's output result is changing from latency.txt to pipeline#.log and r#.jsonl to align with python's output result

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
- run camera simulator
- make build-grpc-go
- make build-ovms-client
- run this script: PIPELINE_PROFILE="grpc_go" sudo -E ./docker-run.sh --workload opencv-ovms --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0
- you should see the result logs inside results/ directory

To test Debug mode:
- add `-e DEBUG="1" \` after `-e PIPELINE_PROFILE="$PIPELINE_PROFILE" \` in docker-run-opencv-ovms.sh
- make build-grpc-go
-  run this script: PIPELINE_PROFILE="grpc_go" sudo -E ./docker-run.sh --workload opencv-ovms --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0
- you should not see any result logs inside results/ directory, instead, run `docker logs dev`, you should see the results output on the console.

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
