### PR TITLE
feat: better error handling for grpc-go while running stream density

### DIFF
--- a/configs/dlstreamer/framework-pipelines/stream_density.sh
+++ b/configs/dlstreamer/framework-pipelines/stream_density.sh
@@ -169,7 +169,7 @@ do
 	do
 		if [ $retry -ge $max_retries ]
 		then
-			echo "ERROR: cannot find all pipeline log files after retries, pipeline may have been failed..."
+			echo "ERROR: cannot find all pipeline log files after retries, pipeline may have been failed..." >> $log
 			exit 1
 		fi
 
@@ -181,10 +181,10 @@ do
 			# to make sure all pipeline log files are present before proceed
 			if [ -f "/tmp/results/pipeline$i.log" ]
 			then
-				echo "found pipeline$i.log file"
+				echo "found pipeline$i.log file" >> $log
 				foundAllLogs=$(( $foundAllLogs + 1 ))
 			else
-				echo "could not find pipeline$i.log file"
+				echo "could not find pipeline$i.log file"  >> $log
 			fi
 		done
 		retry=$(( $retry + 1 ))
@@ -200,9 +200,8 @@ do
 		then
 			echo "Warning: No FPS returned from pipeline$i.log"
 			STREAM_FPS_LIST=`tail -20 /tmp/results/pipeline$i.log`
-			echo "DEBUG: $STREAM_FPS_LIST"
-			#continue
 		fi
+		echo "DEBUG: $STREAM_FPS_LIST" >> $log
         stream_fps_sum=0
         stream_fps_count=0
 


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->
fix some fatal log that quits the grpc-go pipeline. and add retry logic for handling sending request to the model server

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
- git clone this PR
- rebuild the grpc-go: `make build-grpc-go`
- run the stream density from benchmark-scripts directory: `PIPELINE_PROFILE="grpc_go" sudo -E ./benchmark.sh --stream_density 15.0 1 --logdir mytest/data --duration 120 --init_duration 30 --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0 --workload opencv-ovms`
- 

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
