### PR TITLE
refactor: stream density refactor for grpc_go profile

### DIFF
--- a/configs/opencv-ovms/cmd_client/res/grpc_go/configuration.yaml
+++ b/configs/opencv-ovms/cmd_client/res/grpc_go/configuration.yaml
@@ -1,3 +1,4 @@
 OvmsClient:
   PipelineScript: run_grpc_go.sh
   PipelineInputArgs: "" # space delimited like we run the script in command and take those input arguments
+  PipelineStreamDensityRun: "/app/stream_density_run.sh"

--- a/configs/opencv-ovms/grpc_go/Dockerfile
+++ b/configs/opencv-ovms/grpc_go/Dockerfile
@@ -27,4 +27,4 @@ COPY . .
 RUN go mod tidy
 RUN go build -o grpc-go && chmod +x entrypoint.sh
 
-ENTRYPOINT ["./entrypoint.sh"]
+#ENTRYPOINT ["./entrypoint.sh"]

--- a/configs/opencv-ovms/grpc_go/Dockerfile
+++ b/configs/opencv-ovms/grpc_go/Dockerfile
@@ -26,5 +26,3 @@ COPY . .
 
 RUN go mod tidy
 RUN go build -o grpc-go && chmod +x entrypoint.sh
-
-#ENTRYPOINT ["./entrypoint.sh"]

--- a/configs/opencv-ovms/grpc_go/entrypoint.sh
+++ b/configs/opencv-ovms/grpc_go/entrypoint.sh
@@ -5,6 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+containerDisplayPort=8080
+displayPortNum=$(( $cid_count + $containerDisplayPort ))
+echo "displayPortNum=$displayPortNum"
+
 if [ ! -z "$DEBUG" ]
 then
     ./grpc-go -i $inputsrc -u 127.0.0.1:$GRPC_PORT -h 0.0.0.0:$displayPortNum

--- a/configs/opencv-ovms/grpc_go/main.go
+++ b/configs/opencv-ovms/grpc_go/main.go
@@ -99,14 +99,16 @@ func runModelServer(client *grpc_client.GRPCInferenceServiceClient, webcam *gocv
 		var inferResponse *ovms.TensorOutputs
 		retryCnt := 0
 		for {
+			if retryCnt > MAX_RETRY {
+				// there is something broken sending request to the model server, cannot continue...
+				fmt.Println("model infer request error after max retry count: ", MAX_RETRY, "exiting...")
+				os.Exit(1)
+			}
+
 			inferResponse, err = ovms.ModelInferRequest(*client, imgToBytes, modelname, modelVersion)
 			if err != nil {
 				retryCnt++
 				fmt.Println("ovms model infer request error ", err, " retry count: ", retryCnt)
-			} else if retryCnt > MAX_RETRY {
-				// there is something broken sending request to the model server, cannot continue...
-				fmt.Println("model infer request error after max retry count: ", MAX_RETRY, "exiting...")
-				os.Exit(1)
 			} else {
 				break
 			}

--- a/configs/opencv-ovms/grpc_go/stream_density_run.sh
+++ b/configs/opencv-ovms/grpc_go/stream_density_run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+/home/pipeline-server/stream_density_framework-pipelines.sh /app/entrypoint.sh

--- a/configs/opencv-ovms/scripts/run_grpc_go.sh
+++ b/configs/opencv-ovms/scripts/run_grpc_go.sh
@@ -24,8 +24,13 @@ DOCKER_ENTRY="${PipelineStreamDensityRun:=./entrypoint.sh}"
 
 echo "DOCKER_ENTRY: $DOCKER_ENTRY"
 
+if [ "$STREAM_DENSITY_MODE" == 1 ]; then
+	stream_density_envs="-e STREAM_DENSITY_FPS=$STREAM_DENSITY_FPS -e STREAM_DENSITY_INCREMENTS=$STREAM_DENSITY_INCREMENTS -e COMPLETE_INIT_DURATION=$COMPLETE_INIT_DURATION"
+fi
+
 docker run --network host --privileged $rmDocker \
 	-e inputsrc="$inputsrc" -e cid_count="$cid_count" -e GRPC_PORT="$GRPC_PORT" -e DEBUG="$DEBUG" \
+	$stream_density_envs \
 	-v $RUN_PATH/results:/tmp/results \
 	-v $RUN_PATH/configs/dlstreamer/framework-pipelines/stream_density.sh:/home/pipeline-server/stream_density_framework-pipelines.sh \
 	-v $RUN_PATH/configs/opencv-ovms/grpc_go/entrypoint.sh:/app/entrypoint.sh \

--- a/configs/opencv-ovms/scripts/run_grpc_go.sh
+++ b/configs/opencv-ovms/scripts/run_grpc_go.sh
@@ -20,7 +20,14 @@ fi
 
 echo $rmDocker
 
-containerDisplayPort=8080
-displayPortNum=$(( $cid_count + $containerDisplayPort ))
-echo "displayPortNum=$displayPortNum"
-docker run --network host --privileged $rmDocker -e displayPortNum="$displayPortNum" -e inputsrc="$inputsrc" -e cid_count="$cid_count" -e GRPC_PORT="$GRPC_PORT" -e DEBUG="$DEBUG" -v $RUN_PATH/results:/tmp/results --name dev"$cid_count" grpc:dev
+DOCKER_ENTRY="${PipelineStreamDensityRun:=./entrypoint.sh}"
+
+echo "DOCKER_ENTRY: $DOCKER_ENTRY"
+
+docker run --network host --privileged $rmDocker \
+	-e inputsrc="$inputsrc" -e cid_count="$cid_count" -e GRPC_PORT="$GRPC_PORT" -e DEBUG="$DEBUG" \
+	-v $RUN_PATH/results:/tmp/results \
+	-v $RUN_PATH/configs/dlstreamer/framework-pipelines/stream_density.sh:/home/pipeline-server/stream_density_framework-pipelines.sh \
+	-v $RUN_PATH/configs/opencv-ovms/grpc_go/entrypoint.sh:/app/entrypoint.sh \
+	-v $RUN_PATH/configs/opencv-ovms/grpc_go/stream_density_run.sh:/app/stream_density_run.sh \
+	--name dev"$cid_count" grpc:dev bash -c "'$DOCKER_ENTRY'"

--- a/configs/opencv-ovms/scripts/run_grpc_go.sh
+++ b/configs/opencv-ovms/scripts/run_grpc_go.sh
@@ -24,13 +24,9 @@ DOCKER_ENTRY="${PipelineStreamDensityRun:=./entrypoint.sh}"
 
 echo "DOCKER_ENTRY: $DOCKER_ENTRY"
 
-if [ "$STREAM_DENSITY_MODE" == 1 ]; then
-	stream_density_envs="-e STREAM_DENSITY_FPS=$STREAM_DENSITY_FPS -e STREAM_DENSITY_INCREMENTS=$STREAM_DENSITY_INCREMENTS -e COMPLETE_INIT_DURATION=$COMPLETE_INIT_DURATION"
-fi
-
 docker run --network host --privileged $rmDocker \
-	-e inputsrc="$inputsrc" -e cid_count="$cid_count" -e GRPC_PORT="$GRPC_PORT" -e DEBUG="$DEBUG" \
-	$stream_density_envs \
+	--env-file <(env) \
+	-e GRPC_PORT="$GRPC_PORT" -e DEBUG="$DEBUG" \
 	-v $RUN_PATH/results:/tmp/results \
 	-v $RUN_PATH/configs/dlstreamer/framework-pipelines/stream_density.sh:/home/pipeline-server/stream_density_framework-pipelines.sh \
 	-v $RUN_PATH/configs/opencv-ovms/grpc_go/entrypoint.sh:/app/entrypoint.sh \

--- a/docker-run-opencv-ovms.sh
+++ b/docker-run-opencv-ovms.sh
@@ -130,6 +130,7 @@ fi
 if [ "$STREAM_DENSITY_MODE" == 1 ]; then
 	echo "Starting Stream Density"
 	stream_density_mount="-v `pwd`/configs/dlstreamer/framework-pipelines/stream_density.sh:/home/pipeline-server/stream_density_framework-pipelines.sh"
+	grpc_go_mount="-v `pwd`/configs/opencv-ovms/grpc_go/stream_density_run.sh:/app/stream_density_run.sh -v `pwd`/configs/opencv-ovms/grpc_go/entrypoint.sh:/app/entrypoint.sh"
 	stream_density_params="-e STREAM_DENSITY_FPS=$STREAM_DENSITY_FPS -e STREAM_DENSITY_INCREMENTS=$STREAM_DENSITY_INCREMENTS -e COMPLETE_INIT_DURATION=$COMPLETE_INIT_DURATION"
 	echo "DEBUG: $stream_density_params"
 fi
@@ -206,6 +207,7 @@ docker run --network host $cameras $TARGET_USB_DEVICE $TARGET_GPU_DEVICE --user 
 -v `pwd`/configs/opencv-ovms/cmd_client/res:/model_server/client/cmd_client/res \
 -v `pwd`/configs/framework-pipelines:/home/pipeline-server/framework-pipelines \
 -v /var/run/docker.sock:/var/run/docker.sock \
+$grpc_go_mount \
 -e PLATFORM=$PLATFORM \
 -e BARCODE_RECLASSIFY_INTERVAL=$BARCODE_INTERVAL \
 -e OCR_RECLASSIFY_INTERVAL=$OCR_INTERVAL \


### PR DESCRIPTION
  Add the stream density run in configuration yaml file so that it can be dynamically launched inside the grpc go docker container.
  No multiple docker containers running no more.  It is multiple instances of pipeline executable in stream density mode.

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
