### PR TITLE
fix: resolve the GRPC port issue in the script when number of pipelines is more than 10

### DIFF
--- a/docker-run-opencv-ovms.sh
+++ b/docker-run-opencv-ovms.sh
@@ -153,7 +153,7 @@ fi
 ./configs/opencv-ovms/scripts/image_download.sh
 
 # Set GRPC port based on number of servers and clients
-GRPC_PORT=900$cid_count
+GRPC_PORT=$(( 9000 + $cid_count ))
 
 # Modify the config file if the device env is set
 # devices supported CPU, GPU, GPU.x, AUTO, MULTI:GPU,CPU


### PR DESCRIPTION
Fix the docker run ovms launch script to resolve this issue.

Fixes: #211

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**211**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
- git clone this PR
- change directory to benchmark-scripts: `cd ./benchmark-scripts/`
- download the sample video from script if not yet: `./download_sample_videos.sh`
- run 11 pipelines on grpc_python profile for example: `PIPELINE_PROFILE="grpc_python" sudo -E ./benchmark.sh --workload opencv-ovms --pipelines 11 --logdir mytest/data --duration 120 --init_duration 60 --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0`
- observe that the grpc port issue is gone from console or log file
- 

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
