### PR TITLE
fix: update the contribution hyperlink in pull request template markdown

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 <!-- Please check if your PR fulfills the following requirements: -->
 
 - [ ] Added label to the Pull Request for easier discoverability and search
-- [ ] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
+- [ ] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
 - [ ] Every commit is a single defect fix and does not mix feature addition or changes
 - [ ] Unit Tests have been added for new changes
 - [ ] Updated Documentation as relevant to the changes


### PR DESCRIPTION
Currently the Pull Request template markdown file has contribution guideline pointing to EdgeX md file, which should point to this project contribution md file.

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
