### PR TITLE
fix: resolve the empty xpum port setting logic issue for Xeon platform

### DIFF
--- a/benchmark-scripts/collect_platform_metrics.sh
+++ b/benchmark-scripts/collect_platform_metrics.sh
@@ -17,7 +17,7 @@ start_xpum() {
     metrics=0,5,22,24,25
     device=$1
     echo "==== Starting xpumanager capture (gpu $device) ===="
-    let xpumPort=$BASE_XPUM_PORT+$device
+    xpumPort=$(( BASE_XPUM_PORT + device )) || true
     docker run -itd -v /sys/firmware/acpi/tables/MCFG:/pcm/sys/firmware/acpi/tables/MCFG:ro -v /proc/bus/pci/:/pcm/proc/bus/pci/ -v /proc/sys/kernel/nmi_watchdog:/pcm/proc/sys/kernel/nmi_watchdog -v $SOURCE_DIR/$LOG_DIRECTORY:/$cpuOutputDir  --cap-drop ALL --cap-add CAP_SYS_ADMIN --user root -e XPUM_REST_NO_TLS=1 --device /dev/dri:/dev/dri --device /dev/cpu:/dev/cpu --name=xpum$device benchmark:xpu 
     sleep 5
     docker exec xpum$device bash -c "xpumcli dump --rawdata --start -d $device -m $metrics -j"


### PR DESCRIPTION
  Currently, the xpum port number is not set and empty when running in 2nd run of benchmarking, specifically for Xeon system.  This commit gives the default value of xpum port number and thus resolves the issue.

  Fixes: #229

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**229**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
