### PR TITLE
fix: download standard model ovms name instead of name with _

### DIFF
--- a/download_models/downloadModelsFromList.sh
+++ b/download_models/downloadModelsFromList.sh
@@ -21,10 +21,6 @@ for d in */ ; do
             mv "$FP_Dir"*.xml "$FP_Dir"1
         done
     )
-    #TODO: remove below 3 lines when our model name updated to use - instead _
-    newname=${d//[-]/_}
-    echo "$newname"
-    mv "$d" "$newname"
 done
 
 # move back to shared folder


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
downloaded ovms models with standard - in the name instead of _, so this PR just remove the workaround.

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
 run with command:

 PIPELINE_PROFILE="object_detection" RENDER_MODE=0 MQTT=127.0.0.1 sudo -E ./benchmark.sh --pipelines 1 --logdir mytest/data --duration 120 --init_duration 120 --platform core --inputsrc rtsp://127.0.0.1:8554/camera_3 --workload opencv-ovms

the pipeline should run with no error and good result.

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
