### PR TITLE
fix: update make-build-docs to use the current user id and group id instead of root user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ docs-builder-image:
 
 build-docs: docs-builder-image
 	docker run --rm \
+		-u $(shell id -u):$(shell id -g) \
 		-v $(PWD):/docs \
 		-w /docs \
 		$(MKDOCS_IMAGE) \
@@ -92,6 +93,7 @@ build-docs: docs-builder-image
 serve-docs: docs-builder-image
 	docker run --rm \
 		-it \
+		-u $(shell id -u):$(shell id -g) \
 		-p 8008:8000 \
 		-v $(PWD):/docs \
 		-w /docs \


### PR DESCRIPTION
Use the current user id and group id while running make build-docs and make serve-docs.

This resolve the issue of the whole `./docs` directory owned by root after running `make build-docs`

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
- git clone this PR
- run `make build-docs`
- directory listing: `ls -al ./docs` to notice that the directory ownership should now be your user id and group id **instead of root:root**

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
