### PR TITLE
feat: add hadolint Docker makefile target for developers used locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,3 +162,11 @@ run-smoke-tests:
 	@echo "results of smoke tests recorded in the file smoke_tests_output.log"
 	@grep "Failed" ./smoke_tests_output.log || true
 	@grep "===" ./smoke_tests_output.log || true
+
+hadolint:
+	@echo "Run hadolint..."
+	@docker run --rm -v `pwd`:/automated-self-checkout --entrypoint /bin/hadolint hadolint/hadolint:latest \
+	--config /automated-self-checkout/.github/.hadolint.yaml \
+	`sudo find * -type f -name 'Dockerfile*' | xargs -i echo '/automated-self-checkout/{}'` | grep error \
+	| grep -v model_server \
+	|| echo "no issue found"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 .PHONY: list-profiles
 .PHONY: unit-test-profile-launcher build-profile-launcher profile-launcher-status clean-profile-launcher webcam-rtsp
 .PHONY: clean-test
+.PHONY: hadolint
 
 MKDOCS_IMAGE ?= asc-mkdocs
 

--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -60,7 +60,7 @@ RUN wget https://github.com/intel/xpumanager/releases/download/V1.2.6/xpu-smi_1.
 
 RUN \
  wget -q https://repos.influxdata.com/influxdata-archive_compat.key; \
- echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null; \
+ echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null; \
 echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | tee /etc/apt/sources.list.d/influxdata.list
 
 RUN apt-get update -y || true; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends telegraf \


### PR DESCRIPTION
- Add the local makefile target for hadolint on checking error level on Dockerfile locally for developers
- Fix the error level issue from hadolint report

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?
- git clone this PR
-  run `make hadolint` to see if any error issue on Dockerfiles or not

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
