### PR TITLE
feat: refactor the way for the value of cid_count env and GRPC_PORT env

### DIFF
--- a/configs/opencv-ovms/cmd_client/main.go
+++ b/configs/opencv-ovms/cmd_client/main.go
@@ -318,6 +318,15 @@ func (ovmsClientConf *OvmsClientConfig) startOvmsServer() {
 			fallthrough
 		case Ignore.String():
 			log.Println("startup error is ignored due to ignore startup policy")
+			// in this case, we also need to reset the env $GRPC_PORT to the ignored model server's one
+			// otherwise, the client will use the wrong port number
+			ovmsContainerName := ovmsClientConf.OvmsServer.ServerContainerName + os.Getenv(CID_COUNT_ENV)
+			log.Printf("ovmsContainer name: %s", ovmsContainerName)
+			ovmsSrvPortNum, err := getServerGrpcPort(ovmsContainerName)
+			if err != nil {
+				log.Fatalf("failed to get server gRPC port number: %v", err)
+			}
+			os.Setenv(GRPC_PORT_ENV, ovmsSrvPortNum)
 		}
 	}
 

--- a/configs/opencv-ovms/cmd_client/ovmsClientConf_test.go
+++ b/configs/opencv-ovms/cmd_client/ovmsClientConf_test.go
@@ -1,0 +1,89 @@
+// ----------------------------------------------------------------------------------
+// Copyright 2023 Intel Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+// ----------------------------------------------------------------------------------
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetEnvContainerCountAndGrpcPort(t *testing.T) {
+	tests := []struct {
+		name            string
+		launchContainer func(t *testing.T)
+		cleanup         func(t *testing.T)
+		expectedCidCnt  string
+	}{
+		{"first time run", func(t *testing.T) {}, func(t *testing.T) {}, "0"},
+		{"launch one dummy container and check", launchDummyContainer, cleanupDummyContainer, "1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &OvmsClientConfig{
+				OvmsClient: OvmsClientInfo{},
+			}
+
+			origCidEnv := os.Getenv(CID_COUNT_ENV)
+			origGrpcPortEnv := os.Getenv(GRPC_PORT_ENV)
+
+			tt.launchContainer(t)
+
+			client.setEnvContainerCountAndGrpcPort()
+			defer func() {
+				tt.cleanup(t)
+				os.Setenv(CID_COUNT_ENV, origCidEnv)
+				os.Setenv(GRPC_PORT_ENV, origGrpcPortEnv)
+			}()
+
+			newCidCnt := os.Getenv(CID_COUNT_ENV)
+			require.Equal(t, tt.expectedCidCnt, newCidCnt)
+
+			newGrpcPort := os.Getenv(GRPC_PORT_ENV)
+			require.NotEmpty(t, newGrpcPort)
+			grpcPortNum, err := strconv.Atoi(newGrpcPort)
+			require.NoError(t, err)
+			require.True(t, grpcPortNum > defaultGrpcPortFrom)
+		})
+	}
+}
+
+func launchDummyContainer(t *testing.T) {
+	dummyContainerName := "dummy" + profileLaunchedContainerNameSuffix
+	dummyDockerCmd := exec.Command("docker", []string{"run", "--name", dummyContainerName, "busybox"}...)
+	if err := dummyDockerCmd.Run(); err != nil {
+		log.Printf("failed to launch dummy Docker container busybox with container name %s: %v", dummyContainerName, err)
+		t.Fail()
+	}
+	time.Sleep(3)
+}
+
+func cleanupDummyContainer(t *testing.T) {
+	dummyContainerName := "dummy" + profileLaunchedContainerNameSuffix
+	dummyDockerCmd := exec.Command("docker", []string{"rm", dummyContainerName, "-f"}...)
+	if err := dummyDockerCmd.Run(); err != nil {
+		log.Printf("failed to clean up dummy Docker container busybox with container name %s: %v", dummyContainerName, err)
+		t.Fail()
+	}
+}

--- a/configs/opencv-ovms/cmd_client/ovmsGrpcPort.go
+++ b/configs/opencv-ovms/cmd_client/ovmsGrpcPort.go
@@ -1,0 +1,83 @@
+// ----------------------------------------------------------------------------------
+// Copyright 2023 Intel Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+// ----------------------------------------------------------------------------------
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	SERVER_CONTAINER_INSTANCE_ENV = "SERVER_CONTAINER_INSTANCE"
+)
+
+func getServerGrpcPort(srvContainerName string) (string, error) {
+	os.Setenv(SERVER_CONTAINER_INSTANCE_ENV, srvContainerName)
+
+	grpcPortScript := filepath.Join(scriptDir, "get_server_grpc_port.sh")
+	script, err := exec.LookPath(grpcPortScript)
+	if err != nil {
+		return "", fmt.Errorf("failed to get server grpc port script path: %v", err)
+	}
+
+	log.Println("running get server grpc port script:", script)
+	srvGrpcPortCmd := exec.Command(script)
+	stdout, err := srvGrpcPortCmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("failed to get the output from script: %v", err)
+	}
+	stderr, err := srvGrpcPortCmd.StderrPipe()
+	if err != nil {
+		return "", fmt.Errorf("failed to get the error pipe from script: %v", err)
+	}
+	if err := srvGrpcPortCmd.Start(); err != nil {
+		return "", fmt.Errorf("failed to start the script: %v", err)
+	}
+
+	portReader := bufio.NewReader(stdout)
+	resBytes, _ := portReader.ReadString('\n')
+
+	stdErrBytes, _ := io.ReadAll(stderr)
+	if err := srvGrpcPortCmd.Wait(); err != nil {
+		return "", fmt.Errorf("found error while executing get server grpc port scripts- stdErrMsg: %s, Err: %v", string(stdErrBytes), err)
+	}
+
+	srvPortNum := strings.TrimSuffix(string(resBytes), fmt.Sprintln())
+
+	log.Printf("srvPortNum from OVMS server %s: %s", srvContainerName, srvPortNum)
+
+	// verify it is an integer
+	if len(srvPortNum) > 0 {
+		// verify the output is an integer
+		_, err := strconv.Atoi(srvPortNum)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse the OVMS server port number for %s: %v", srvContainerName, err)
+		}
+	} else {
+		return "", fmt.Errorf("srvPortNum is empty for %s, cannot continue", srvContainerName)
+	}
+
+	return srvPortNum, nil
+}

--- a/configs/opencv-ovms/cmd_client/portfinder/findPort.go
+++ b/configs/opencv-ovms/cmd_client/portfinder/findPort.go
@@ -21,12 +21,10 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"time"
 )
 
 const (
 	defaultStartPort = 9000
-	testTimeout      = 500 * time.Millisecond
 )
 
 type PortFinder struct {

--- a/configs/opencv-ovms/cmd_client/portfinder/findPort.go
+++ b/configs/opencv-ovms/cmd_client/portfinder/findPort.go
@@ -1,0 +1,55 @@
+// ----------------------------------------------------------------------------------
+// Copyright 2023 Intel Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+// ----------------------------------------------------------------------------------
+
+package portfinder
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"time"
+)
+
+const (
+	defaultStartPort = 9000
+	testTimeout      = 500 * time.Millisecond
+)
+
+type PortFinder struct {
+	IpAddress string
+}
+
+func (pf *PortFinder) GetFreePortNumber(from int) int {
+	if from <= 0 {
+		return defaultStartPort
+	}
+
+	if tcpAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:0", pf.IpAddress)); err == nil {
+		var tcpLis *net.TCPListener
+		if tcpLis, err = net.ListenTCP("tcp", tcpAddr); err == nil {
+			defer tcpLis.Close()
+			portNum := tcpLis.Addr().(*net.TCPAddr).Port
+			if portNum < from { // retry again until we find one port number is bigger
+				return pf.GetFreePortNumber(from)
+			}
+			return portNum
+		}
+	} else {
+		log.Printf("resolve error on tcpAddr: %v", tcpAddr)
+	}
+	return defaultStartPort
+}

--- a/configs/opencv-ovms/cmd_client/portfinder/findPort_test.go
+++ b/configs/opencv-ovms/cmd_client/portfinder/findPort_test.go
@@ -1,0 +1,48 @@
+// ----------------------------------------------------------------------------------
+// Copyright 2023 Intel Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+//
+// ----------------------------------------------------------------------------------
+
+package portfinder
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScan(t *testing.T) {
+	tests := []struct {
+		name string
+		from int
+	}{
+		{"good free port at least bigger than defaultPort", defaultStartPort},
+		{"good free port at least bigger than from", 0},
+		{"good free port at least bigger than from a bigger", 35000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			portFinder := PortFinder{
+				IpAddress: "localhost",
+			}
+
+			result := portFinder.GetFreePortNumber(tt.from)
+			log.Println("result=", result)
+			require.True(t, result > tt.from)
+		})
+	}
+}

--- a/configs/opencv-ovms/scripts/get_server_grpc_port.sh
+++ b/configs/opencv-ovms/scripts/get_server_grpc_port.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+docker inspect "$SERVER_CONTAINER_INSTANCE" | docker run -i --rm -v ./:/app ghcr.io/jqlang/jq -r '.[].Args[3]'

--- a/run-ovms.sh
+++ b/run-ovms.sh
@@ -37,7 +37,7 @@ then
 	TAG=$CONTAINER_IMAGE_OVERRIDE
 fi
 
-cid_count=`ps aux | grep profile-launcher | grep -v grep | wc -l`
+#cid_count=`ps aux | grep profile-launcher | grep -v grep | wc -l`
 
 #echo "barcode_disabled: $BARCODE_DISABLED, barcode_interval: $BARCODE_INTERVAL, ocr_interval: $OCR_INTERVAL, ocr_device: $OCR_DEVICE, ocr_disabled=$OCR_DISABLED, class_disabled=$CLASSIFICATION_DIABLED"
 re='^[0-9]+$'
@@ -81,7 +81,7 @@ fi
 ./configs/opencv-ovms/scripts/image_download.sh
 
 # Set GRPC port based on number of servers and clients
-GRPC_PORT=$(( 9000 + $cid_count ))
+#GRPC_PORT=$(( 9000 + $cid_count ))
 
 # Modify the config file if the device env is set
 # devices supported CPU, GPU, GPU.x, AUTO, MULTI:GPU,CPU
@@ -95,7 +95,7 @@ docker run --rm -v `pwd`/configs/opencv-ovms/models/2022:/configFiles -e DEVICE=
 # PIPELINE_PROFILE="grpc_python" sudo -E ./run.sh --workload ovms --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0
 PIPELINE_PROFILE="${PIPELINE_PROFILE:=grpc_python}"
 echo "starting profile-launcher with pipeline profile: $PIPELINE_PROFILE ..."
-
+current_time=$(date "+%Y.%m.%d-%H.%M.%S")
 cameras="$cameras" \
 TARGET_USB_DEVICE="$TARGET_USB_DEVICE" \
 TARGET_GPU_DEVICE="$TARGET_GPU_DEVICE" \
@@ -110,14 +110,12 @@ OCR_RECLASSIFY_INTERVAL=$OCR_INTERVAL \
 OCR_DEVICE=$OCR_DEVICE \
 LOG_LEVEL=$LOG_LEVEL \
 LOW_POWER="$LOW_POWER" \
-cid_count=$cid_count \
 STREAM_DENSITY_MODE=$STREAM_DENSITY_MODE \
 INPUTSRC="$INPUTSRC" \
 STREAM_DENSITY_FPS=$STREAM_DENSITY_FPS \
 STREAM_DENSITY_INCREMENTS=$STREAM_DENSITY_INCREMENTS \
 COMPLETE_INIT_DURATION=$COMPLETE_INIT_DURATION \
 CPU_ONLY="$CPU_ONLY" \
-GRPC_PORT="$GRPC_PORT" \
 PIPELINE_PROFILE="$PIPELINE_PROFILE" \
 AUTO_SCALE_FLEX_140="$AUTO_SCALE_FLEX_140" \
-./profile-launcher -configDir $(dirname $(readlink ./profile-launcher)) &
+./profile-launcher -configDir $(dirname $(readlink ./profile-launcher)) > ./results/profile-launcher."$current_time".log 2>&1 &

--- a/run-ovms.sh
+++ b/run-ovms.sh
@@ -37,9 +37,6 @@ then
 	TAG=$CONTAINER_IMAGE_OVERRIDE
 fi
 
-#cid_count=`ps aux | grep profile-launcher | grep -v grep | wc -l`
-
-#echo "barcode_disabled: $BARCODE_DISABLED, barcode_interval: $BARCODE_INTERVAL, ocr_interval: $OCR_INTERVAL, ocr_device: $OCR_DEVICE, ocr_disabled=$OCR_DISABLED, class_disabled=$CLASSIFICATION_DIABLED"
 re='^[0-9]+$'
 if grep -q "video" <<< "$INPUTSRC"; then
 	echo "assume video device..."
@@ -79,9 +76,6 @@ fi
 
 # make sure sample image is downloaded or existing:
 ./configs/opencv-ovms/scripts/image_download.sh
-
-# Set GRPC port based on number of servers and clients
-#GRPC_PORT=$(( 9000 + $cid_count ))
 
 # Modify the config file if the device env is set
 # devices supported CPU, GPU, GPU.x, AUTO, MULTI:GPU,CPU

--- a/run_smoke_test.sh
+++ b/run_smoke_test.sh
@@ -135,7 +135,7 @@ teardown
 
 #5. gst profile:
 # gst RTSP
-make build-soc
+make build-dlstreamer
 echo "Running gst profile..."
 gst_rtsp_input_src="rtsp://127.0.0.1:8554/camera_0"
 PIPELINE_PROFILE="gst" sudo -E ./run.sh --workload ovms --platform core --inputsrc "$gst_rtsp_input_src"

--- a/run_smoke_test.sh
+++ b/run_smoke_test.sh
@@ -6,7 +6,6 @@
 #
 
 RESULT_DIR=./results
-GRPC_PORT=${GRPC_PORT:=9000}
 
 # a quick spot test script to smoke testing some of pipeline profiles
 #
@@ -88,15 +87,6 @@ waitForLogFile() {
 
 # initial setup
 setup
-
-# verify that if GRPC_PORT is free and failed if not
-isPortFree=$(sudo netstat -lpn | grep "$GRPC_PORT")
-if [ -n "$isPortFree" ]
-then
-    echo "Failed: the required GRPC port $GRPC_PORT is busy, please release that port first"
-    teardown
-    exit
-fi
 
 # 1. test profile: should run and exit without any error
 echo "Running test profile..."


### PR DESCRIPTION
- Make the cid_count value setting more robust when the client side containers crashed by other containers.
- Make getting GRPC_PORT number more robust by free opened port from system
- Add profile-launcher log output into file as we can track its running contents for easier debugging information
- Update run-ovms.sh and run-smoke-test.sh to remove cid_count and GRPC_PORT check as it is taken care by profile-launcher now

Closes: #328

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [x] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**328**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
<!-- How can the reviewers test your change? -->
- git clone this PR
- unit-test: `make unit-test-profile-launcher`  should all PASSED
- build profile-launcher: `make build-profile-launcher` 
- run camera-simulator: `make run-camera-simulator`
- functional test: you can launch multiple instance profiles to see the behavior
```console
1. PIPELINE_PROFILE="object_detection" RENDER_MODE=1 sudo -E ./run.sh --workload ovms --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0
2. wait until see the re-streaming video with inferencing result window pop up 
3. docker ps -a
4. launch another pipeeline profile:   PIPELINE_PROFILE="classification" RENDER_MODE=1 sudo -E ./run.sh --workload ovms --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0
5. and you should also see the inferencing result windows pop up
6. docker ps -a to see instances of those containers launched by profile-launcher
```
- smoke test: `make run-smoke-tests` should see ALL PASSED

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
