### PR TITLE
fix: rename console output log file to rNUM.jsonl

### DIFF
--- a/configs/opencv-ovms/gst_capi/run_gst_capi.sh
+++ b/configs/opencv-ovms/gst_capi/run_gst_capi.sh
@@ -57,4 +57,4 @@ DETECTION_THRESHOLD="$DETECTION_THRESHOLD" \
 BARCODE="$BARCODE" \
 OCR_DEVICE="$OCR_DEVICE" \
 $bash_cmd \
-2>&1 | tee >/tmp/results/j$cid_count.jsonl >(stdbuf -oL sed -n -e 's/^.*FPS: //p' | stdbuf -oL cut -d , -f 1 > /tmp/results/pipeline$cid_count.log)
+2>&1 | tee >/tmp/results/r$cid_count.jsonl >(stdbuf -oL sed -n -e 's/^.*FPS: //p' | stdbuf -oL cut -d , -f 1 > /tmp/results/pipeline$cid_count.log)


### PR DESCRIPTION
rename console output log file to jNUM.jsonl to fix stream density report

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->

## Issue this PR will close

close: #**issue_number**

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
PIPELINE_PROFILE="capi_yolov5" sudo -E ./benchmark.sh --stream_density 14.9 --logdir mytest/data --duration 1
40 --init_duration 40 --platform core --inputsrc rtsp://127.0.0.1:8554/camera_0

run above cmd to start stream density before this PR, you will see benchmark-scripts/results folder is empty after stream density is done.

clone this PR, run the same cmd above, after stream density is done successfully, you will see benchmark-scripts/results/ folder is filled with same content of ../results/ and you will see benchmark measurement have been calculated in mytest/ folder with summary.

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
