### PR TITLE
bug: fix errors when switching to DEVICE_ENV=res/all-gpu.env

### DIFF
--- a/src/pipelines/yolov5s.sh
+++ b/src/pipelines/yolov5s.sh
@@ -9,10 +9,16 @@ PRE_PROCESS="${PRE_PROCESS:=""}" #""|pre-process-backend=vaapi-surface-sharing|p
 AGGREGATE="${AGGREGATE:="gvametaaggregate name=aggregate !"}" # Aggregate function at the end of the pipeline ex. "" | gvametaaggregate name=aggregate
 PUBLISH="${PUBLISH:="name=destination file-format=2 file-path=/tmp/results/r$cid.jsonl"}" # address=localhost:1883 topic=inferenceEvent method=mqtt
 
-if [ "$RENDER_MODE" == "1" ]; then
-    OUTPUT="${OUTPUT:="! videoconvert ! video/x-raw,format=I420 ! gvawatermark ! videoconvert ! fpsdisplaysink video-sink=ximagesink sync=true --verbose"}"
+if [ "$DECODE" == "vaapidecodebin" ]; then
+    POSTPROC="! vaapipostproc"
 else
-    OUTPUT="${OUTPUT:="! fpsdisplaysink video-sink=fakesink sync=true --verbose"}"
+    POSTPROC="! videoconvert"
+fi 
+
+if [ "$RENDER_MODE" == "1" ]; then
+    OUTPUT="${OUTPUT:="$POSTPROC ! video/x-raw,format=I420 ! gvawatermark ! videoconvert ! fpsdisplaysink video-sink=ximagesink sync=true --verbose"}"
+else
+    OUTPUT="${OUTPUT:="$POSTPROC ! fpsdisplaysink video-sink=fakesink sync=true --verbose"}"
 fi
 
 echo "decode type $DECODE"

--- a/src/pipelines/yolov5s_effnetb0.sh
+++ b/src/pipelines/yolov5s_effnetb0.sh
@@ -19,10 +19,16 @@ CLASSIFICATION_OPTIONS="${CLASSIFICATION_OPTIONS:="reclassify-interval=1 $DETECT
 
 PUBLISH="${PUBLISH:="name=destination file-format=2 file-path=/tmp/results/r$cid.jsonl"}" # address=localhost:1883 topic=inferenceEvent method=mqtt
 
-if [ "$RENDER_MODE" == "1" ]; then
-    OUTPUT="${OUTPUT:="! videoconvert ! video/x-raw,format=I420 ! gvawatermark ! videoconvert ! fpsdisplaysink video-sink=ximagesink sync=true --verbose"}"
+if [ "$DECODE" == "vaapidecodebin" ]; then
+    POSTPROC="! vaapipostproc"
 else
-    OUTPUT="${OUTPUT:="! fpsdisplaysink video-sink=fakesink sync=true --verbose"}"
+    POSTPROC="! videoconvert"
+fi 
+
+if [ "$RENDER_MODE" == "1" ]; then
+    OUTPUT="${OUTPUT:="$POSTPROC ! video/x-raw,format=I420 ! gvawatermark ! videoconvert ! fpsdisplaysink video-sink=ximagesink sync=true --verbose"}"
+else
+    OUTPUT="${OUTPUT:="$POSTPROC ! fpsdisplaysink video-sink=fakesink sync=true --verbose"}"
 fi
 
 echo "Run run yolov5s with efficientnet classification pipeline on $DEVICE with batch size = $BATCH_SIZE"


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Added label to the Pull Request for easier discoverability and search
- [ ] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
- [ ] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
Switches the videoconvert element with vaapipostproc when vaapidecodebin is used to avoid memory compatibility issues

## Issue this PR will close

close: #669

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable
DEVICE_ENV=res/all-gpu.env make run-render-mode
DEVICE_ENV=res/all-gpu.env PIPELINE_SCRIPT=yolov5s_effnetb0.sh make run-render-mode
Both commands should run with the same output as when DEVICE_ENV is not set

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/automated-self-checkout )
